### PR TITLE
Encouraging message component

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
   <link rel="stylesheet" href="public/styles/main.css">
+  <link rel="stylesheet" href="public/styles/message.css">
 </head>
 
 <body>

--- a/public/styles/message.css
+++ b/public/styles/message.css
@@ -1,0 +1,47 @@
+.message {
+  --page-pad: 16;
+  --min-screen:  320;
+  --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: absolute;
+  z-index: 1; /* adjust if necessary */
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  inline-size: calc((var(--min-screen) - 2 * var(--page-pad)) / 16 * 1rem);
+  border: 2px solid hsla(0, 0%, 100%, 1);
+  border-radius: 32px;
+  padding: 17px 16px 15px 16px;
+  background-color: hsla(203, 85%, 95%, 1);
+  box-shadow: 0 6px 6px hsla(0, 0%, 0%, 0.15);
+  color: hsla(201, 64%, 50%, 1);
+  white-space: pre-wrap;
+  animation: fade-in 1s var(--expo-out) 0.5s both;
+}
+
+@media screen and (min-width: 414px) {
+  .message {
+    inline-size: calc(374 / 16 * 1rem);
+  }
+}
+
+.message__emoji {
+  font-size: calc(30 / 16 * 1rem);
+  line-height: calc(24 / 30);
+}
+
+.message__text {
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 50%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import GoogleMapReact from "google-map-react";
 import axios from "axios";
+import Message from './components/Message';
 
 const Marker = () => <div className="marker"><img className="pin" src="/public/images/map-pin.svg" /></div>;
 
@@ -108,6 +109,9 @@ export function App({ gmApiKey }) {
             <Marker key={tap.id} lat={tap.latitude} lng={tap.longitude} />
           ) : null }
         </GoogleMapReact>
+
+        {/* TODO: add a logic based on spot's availability */}
+        {false && <Message />}
       </div>
 
       <div className="container-lg">

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const lang = "en"; // TODO: remove when i18n is supported
+
+// TODO: add ja translation
+// TODO: check with product if there are other variations
+const data = {
+  emoji: "😅",
+  en: "We’ve noticed that there are no refill spots close to you. Would you like to add a new refill spot?",
+  ja: "",
+};
+
+const Message = ({ emoji = data.emoji, text = data[lang] }) => {
+  return (
+    <div className="message">
+      {emoji && <span className="message__emoji">{emoji}</span>}
+      <div className="message__text">{text}</div>
+    </div>
+  );
+};
+export default Message;


### PR DESCRIPTION
This is a PR for #10 and is still work-in-progress.

The message component is generic enough to be used for other purposes (emoji can be hidden), so it's not specific for displaying a message when a refill spot is not available.

Progress so far:
<img src="https://user-images.githubusercontent.com/101444904/178249704-9458b2c3-b584-43c8-91f6-360bbe521428.jpg" width="400px" />

TODO (extracted from source code):
- add a logic based on spot's availability to hide/display the message
- remove hard-coded language when i18n is supported
- add Japanese translation (only English for now)
- check if there are other variations
- (new) verify the UX, e.g. how the message should appear, how the user can remove it (if possible)