### PR TITLE
modal close button bug fixed

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -343,6 +343,7 @@ footer .nav-link i {
 
 .back-button {
   position: absolute;
+  padding: 0;
   top: 0;
   left: 0;
   height: 32px;


### PR DESCRIPTION
This should make it so that the back button, which previously appeared out of position due to iOS default button css, in its ideal position