### PR TITLE
fix: multiple setState execution use sometimes causing infinite loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -352,15 +352,13 @@ export function App({ gmApiKey, gaTag }) {
   };
 
   const startedRequest = (randomRef) => {
-    setRequestsInProgress([requestsInProgress, randomRef]);
+    setRequestsInProgress(prev => [...prev, randomRef]);
   };
 
   const finishedRequest = (randomRef) => {
-    Array.isArray(requestsInProgress)
-      ? setRequestsInProgress(
-          requestsInProgress.filter((item) => item !== randomRef)
-        )
-      : null;
+    setRequestsInProgress(prev => 
+      prev.filter((item) => item !== randomRef)
+    )
   };
 
   // Ask user for permission to give device location
@@ -434,20 +432,8 @@ export function App({ gmApiKey, gaTag }) {
   }, [taps, setInitialLoad, initialLoad, setTaps, locale, userToken]);
 
   useEffect(() => {
-    if (Object.keys(coordinate).length > 0) {
-      getTapsWhenMapsMoved(coordinate);
-    }
-  }, [coordinate]);
-
-  useEffect(() => {
     localStorage.setItem(LANG_PREF_KEY, locale);
   }, [locale]);
-
-  useEffect(() => {
-    if (Object.keys(coordinate).length > 0) {
-      getTapsWhenMapsMoved(coordinate);
-    }
-  }, [coordinate]);
 
   useEffect(() => {
     if (Object.keys(coordinate).length > 0) {


### PR DESCRIPTION
Users sometimes encounter an infinite loading indicator when moving on the map.

https://drive.google.com/file/d/1N3g2wunXSfXiabgUYZQyzTw6PBmRc8y9/view?usp=sharing

Loading indicator appears when `requestsInProgress` length is not zero. Adding console.log, we can see that even if we cleaned up a request with 8kozf ref (seen in the first red box), that request persists. Thus, the loading indicator keeps appearing.
<img width="450" alt="Screenshot 2024-08-19 at 16 50 39" src="https://github.com/user-attachments/assets/58520e17-903d-45e4-990f-0718188bcdce">

This is because multiple `setRequestsInProgress` directly references `requestsInProgress`, as seen [here](https://github.com/mymizu/mymizu-web/blob/main/src/App.jsx#L355C5-L355C26) and [here](https://github.com/mymizu/mymizu-web/blob/9fd21aa9145e7cde7b825382b702c3757aaaef01/src/App.jsx#L361). When  `setRequestsInProgress` is executed multiple times before react finishes render, [the react docs](https://react.dev/learn/queueing-a-series-of-state-updates) mentions that only the last execution will change the state.

[We can use callback instead](https://react.dev/learn/queueing-a-series-of-state-updates#updating-the-same-state-multiple-times-before-the-next-render) in `setRequestsInProgress` to correctly update the state.

Now the web app can correctly handle multiple `setRequestsInProgress`
<img width="387" alt="Screenshot 2024-08-19 at 17 29 25" src="https://github.com/user-attachments/assets/70bb4eb5-09f2-4151-a3a6-e1981abd833e">

I also removed duplicate `useEffects` that trigger `setRequestsInProgress`.


In the future, we might want to convert [useEffect to callback ](https://react.dev/learn/you-might-not-need-an-effect) to handle `GoogleMapReact`'s `onChange` make the code more readable and maintainable.
