### PR TITLE
fix: map jumps to current location even if there is refill spot slug

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ import Metrics from "./components/Metrics";
 import { transformCardData } from "./utils/transformCardData";
 import { Modal } from "./components/Modal";
 import { useLang } from "./utils/useLang";
-import getSlug from "./utils/getSlug";
 import { Marker } from "./components/Marker";
 import { CurrentLocationIcon } from "./components/CurrentLocationIcon";
 import { Search } from "./components/Search";
@@ -19,6 +18,7 @@ import debounce from "lodash.debounce";
 import classnames from "classnames";
 import { ShareModal } from "./components/ShareModal";
 import CurrentLocationButton from "./components/Buttons/CurrentLocationButton";
+import { useRefillSpotSlug } from "./hooks/useRefillSpotSlug";
 
 const translations = {
   en: require("./translations/en.json"),
@@ -63,6 +63,8 @@ export function App({ gmApiKey, gaTag }) {
   const [userLatitude, setUserLatitude] = useState(0);
   const [userLongitude, setUserLongitude] = useState(0);
   const [currentLocationLoaded, setCurrentLocationLoaded] = useState(false);
+
+  const slug = useRefillSpotSlug();
 
   const handleSearchQuery = (query) => {
     googleMapFn.search(query, searchResultCallback);
@@ -391,8 +393,10 @@ export function App({ gmApiKey, gaTag }) {
 
   // Get geolocation onload
   useEffect(() => {
-    getGeoLocation();
-  }, [])
+    if (slug === "") {
+      getGeoLocation();
+    }
+  }, [slug]);
 
   useEffect(() => {
     const token = localStorage.getItem(USER_TOKEN_KEY);
@@ -444,8 +448,6 @@ export function App({ gmApiKey, gaTag }) {
   useEffect(() => {
     if (userToken) {
       const load = async () => {
-        const REFILL_SPOT_ROUTE = "/refill/"; // TODO: constants
-        const slug = getSlug(REFILL_SPOT_ROUTE);
         if (slug) {
           const reqRef = getRequestRef();
           startedRequest(reqRef);
@@ -480,7 +482,7 @@ export function App({ gmApiKey, gaTag }) {
       };
       load();
     }
-  }, [userToken]);
+  }, [slug, userToken]);
 
   return (
     <IntlProvider

--- a/src/hooks/useRefillSpotSlug.js
+++ b/src/hooks/useRefillSpotSlug.js
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+import getSlug from "../utils/getSlug";
+
+export const useRefillSpotSlug = () => {
+  const [slug, setSlug] = useState();
+
+  useEffect(() => {
+    const REFILL_SPOT_ROUTE = "/refill/";
+    setSlug(getSlug(REFILL_SPOT_ROUTE));
+  }, [])
+
+  return slug
+}


### PR DESCRIPTION
Fix the bug according to this [Notion](https://www.notion.so/mymizu/Web-App-Fix-map-jumping-to-current-location-even-on-dedicated-refill-spot-URL-6403b8250c0343e3b237e5f95739c746?pvs=4) document.

Relevant discussion [here](https://mymizu.slack.com/archives/C01KX4DDB7X/p1724312520800249?thread_ts=1724215273.385159&cid=C01KX4DDB7X).

Change behavior so that we center on user location in the below 2 conditions only:
1. When users first enter the website _and_ there is no refill spot slug (https://map.mymizu.co/)
2. When users click the center button in the bottom right.

To fulfill condition 1, I add `slug === ""` check.

Since `slug` is used in two places, I refactored it into a custom hook.

Check the new behavior [on this video](https://www.loom.com/share/6b9b5cef28f04d839c626915a71181ce?sid=937b77a0-054b-4249-a38e-e0ebca96e41e).